### PR TITLE
Optimize step_two

### DIFF
--- a/step_two/CMakeLists.txt
+++ b/step_two/CMakeLists.txt
@@ -9,7 +9,8 @@ endif()
 
 #set(CMAKE_CXX_FLAGS "${CMAKE_CUDA_FLAGS} -O3 -g -Wa,-aslh")
 # run with make > bench.dump
-set(CMAKE_CXX_FLAGS "${CMAKE_CUDA_FLAGS} -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CUDA_FLAGS} -O3 -mavx -mfma -mavx2")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CUDA_FLAGS} -O0 -g -mavx -mfma -mavx2")
 
 include_directories(${TORCH_DIR}/include ${TORCH_DIR}/include/torch/csrc/api/include)
 set(TORCH_LIBRARIES 

--- a/step_two/CMakeLists.txt
+++ b/step_two/CMakeLists.txt
@@ -7,6 +7,8 @@ else()
   message("Found TORCH_DIR:${TORCH_DIR}")
 endif()
 
+#set(CMAKE_CXX_FLAGS "${CMAKE_CUDA_FLAGS} -O3 -g -Wa,-aslh")
+# run with make > bench.dump
 set(CMAKE_CXX_FLAGS "${CMAKE_CUDA_FLAGS} -O3")
 
 include_directories(${TORCH_DIR}/include ${TORCH_DIR}/include/torch/csrc/api/include)

--- a/step_two/interpolate.h
+++ b/step_two/interpolate.h
@@ -1,10 +1,35 @@
 #include <vector>
 #include <ATen/native/TensorIterator.h>
 
+/*
+struct Indexer {
+  Indexer(int64_t num_indexers, char** indexers, const int64_t* indexer_strides,
+          IntArrayRef original_sizes, IntArrayRef original_strides)
+    : num_indexers(num_indexers)
+    , indexers(indexers)
+    , indexer_strides(indexer_strides) {
+    AT_ASSERT(original_strides.size() == num_indexers);
+    AT_ASSERT(original_sizes.size() == num_indexers);
+  }
+
+  int64_t num_indexers;
+  char** indexers;
+  const int64_t* indexer_strides;
+
+  int64_t get(int64_t idx) {
+    int64_t offset = 0;
+    for (int j = 0; j < num_indexers; j++) {
+      int64_t value = *(int64_t*)&indexers[j][idx * indexer_strides[j]];
+      offset += value * original_strides[j];
+    }
+    return offset;
+  }
+};
+*/
 
 template <typename scalar_t, typename func_t>
 void ti_cpu_upsample_linear(
-  at::TensorIterator& iter, int64_t y_stride, int64_t x_stride, const func_t& f, bool serial_execution=false
+  at::TensorIterator& iter, const func_t& f, bool serial_execution=false
 ) {
   // When launch the index parallel version, set a relative samll grain size less than the INTERNAL::GRAIN_SIZE
   // to make the whole available thread numbers get more balanced work load and a better cache location.
@@ -23,15 +48,52 @@ void ti_cpu_upsample_linear(
     char* wy1 = data[9];
 
     int64_t offset1, offset2, offset3, offset4;
+    TORCH_CHECK(strides[2] == strides[4]); // ix
+    TORCH_CHECK(strides[6] == strides[8]); // iy
+    TORCH_CHECK(strides[3] == strides[5]); // wx
+    TORCH_CHECK(strides[7] == strides[9]); // wy
 
-    for (int64_t i = 0; i < n; i++) {
-      offset1 = *(int64_t*)&ix0[i * strides[2]] * x_stride;
-      offset2 = *(int64_t*)&ix1[i * strides[4]] * x_stride;
-      offset3 = *(int64_t*)&iy0[i * strides[6]] * y_stride;
-      offset4 = *(int64_t*)&iy1[i * strides[8]] * y_stride;
-      f(dst + strides[0] * i, src + strides[1] * i, \
-        offset1, offset2, wx0 + strides[3] * i, wx1 + strides[5] * i, \
-        offset3, offset4, wy0 + strides[7] * i, wy1 + strides[9] * i);
+    if (strides[2] == 0) {
+      offset1 = *(int64_t*)&ix0[0];
+      offset2 = *(int64_t*)&ix1[0];
+      TORCH_CHECK(strides[3] == 0);
+      TORCH_CHECK(strides[5] == 0);
+      for (int64_t i = 0; i < n; i++) {
+        offset3 = *(int64_t*)&iy0[i * strides[6]];
+        offset4 = *(int64_t*)&iy1[i * strides[8]];
+        f(dst + strides[0] * i, src + strides[1] * i, \
+          offset1, offset2, wx0, wx1, \
+          offset3, offset4, wy0 + strides[7] * i, wy1 + strides[9] * i);
+      }
+    } else if (strides[6] == 0) {
+      offset3 = *(int64_t*)&iy0[0];
+      offset4 = *(int64_t*)&iy1[0];
+      TORCH_CHECK(strides[7] == 0);
+      TORCH_CHECK(strides[9] == 0);
+      TORCH_CHECK(strides[1] == 0); // TODO need to add this case
+
+      if (strides[2] == sizeof(int64_t) && strides[4] && sizeof(int64_t) && strides[3] == sizeof(float) && strides[5] == sizeof(float) && strides[0] == sizeof(scalar_t)) {
+      for (int64_t i = 0; i < n; i++) {
+        offset1 = *(int64_t*)&ix0[i * strides[2]];
+        offset2 = *(int64_t*)&ix1[i * strides[4]];
+        f(dst + strides[0] * i, src, \
+          offset1, offset2, wx0 + strides[3] * i, wx1 + strides[5] * i, \
+          offset3, offset4, wy0, wy1);
+      }
+      } else {
+        TORCH_CHECK(false, "Not supposed to be here ", strides[0], " ", strides[1]);
+      }
+    } else {
+      for (int64_t i = 0; i < n; i++) {
+        offset1 = *(int64_t*)&ix0[i * strides[2]];
+        offset2 = *(int64_t*)&ix1[i * strides[4]];
+        offset3 = *(int64_t*)&iy0[i * strides[6]];
+        offset4 = *(int64_t*)&iy1[i * strides[8]];
+        f(dst + strides[0] * i, src + strides[1] * i, \
+          offset1, offset2, wx0 + strides[3] * i, wx1 + strides[5] * i, \
+          offset3, offset4, wy0 + strides[7] * i, wy1 + strides[9] * i);
+      }
+
     }
   };
   if (serial_execution) {
@@ -44,7 +106,7 @@ void ti_cpu_upsample_linear(
 
 
 void ti_compute_indices_weights(
-  long input_size, long output_size, at::Tensor & input_index0, at::Tensor & input_index1, at::Tensor & lambda0, at::Tensor & lambda1
+  long input_size, long output_size, int64_t stride, at::Tensor & input_index0, at::Tensor & input_index1, at::Tensor & lambda0, at::Tensor & lambda1
 ) {
     auto scale = float(input_size) / output_size;
     // ((at::arange(output_size).to(at::kFloat) + 0.5) * scale - 0.5).clamp(0);
@@ -54,6 +116,39 @@ void ti_compute_indices_weights(
     lambda0 = 1.0 - lambda1;
     input_index0 = input_index.to(at::kLong);
     input_index1 = (input_index0 + 1).clamp(0, input_size - 1);
+}
+
+void ti_compute_indices_weights_faster(
+  int64_t input_size, int64_t output_size, int64_t stride, at::Tensor & input_index0, at::Tensor & input_index1, at::Tensor & lambda0, at::Tensor & lambda1
+) {
+    auto scale = float(input_size) / output_size;
+    input_index0 = at::empty({output_size, }, at::CPU(at::kLong));
+    input_index1 = at::empty({output_size, }, at::CPU(at::kLong));
+    lambda1 = at::empty({output_size, }, at::CPU(at::kFloat));
+    lambda0 = at::empty({output_size, }, at::CPU(at::kFloat));
+
+    auto input_index0_ptr = (int64_t *) input_index0.data_ptr();
+    auto input_index1_ptr = (int64_t *) input_index1.data_ptr();
+    auto lambda1_ptr = (float *) lambda1.data_ptr();
+    auto lambda0_ptr = (float *) lambda0.data_ptr();
+    float xf;
+    long xl;
+
+    // auto input_index = real_input_index.floor();
+    // lambda1 = real_input_index - input_index;
+    // lambda0 = 1.0 - lambda1;
+    // input_index0 = input_index.to(at::kLong);
+    // input_index1 = (input_index0 + 1).clamp(0, input_size - 1);
+
+    for (uint64_t i=0; i<output_size; i++) {
+        xf = std::max((float)((i + 0.5f) * scale - 0.5), 0.0f);
+        xl = (long) xf;
+        input_index0_ptr[i] = xl * stride;
+        input_index1_ptr[i] = std::min(xl + 1, input_size - 1) * stride;
+        xf -= (float) xl;
+        lambda1_ptr[i] = xf;
+        lambda0_ptr[i] = 1.0 - xf;
+    }
 }
 
 
@@ -77,10 +172,15 @@ at::Tensor ti_upsample_bilinear2d_kernel_impl(
     strides[3] = 0;
     auto restrided_input = input.as_strided(shape, strides);
 
+    int64_t element_size_bytes = input.element_size();
+    int64_t x_indexed_stride = input.stride(3) * element_size_bytes;
+    int64_t y_indexed_stride = input.stride(2) * element_size_bytes;
+
+
     at::Tensor ix0, ix1, wx0, wx1;
     at::Tensor iy0, iy1, wy0, wy1;
-    ti_compute_indices_weights(input.size(3), output_size[1], ix0, ix1, wx0, wx1);
-    ti_compute_indices_weights(input.size(2), output_size[0], iy0, iy1, wy0, wy1);
+    ti_compute_indices_weights_faster(input.size(3), output_size[1], x_indexed_stride, ix0, ix1, wx0, wx1);
+    ti_compute_indices_weights_faster(input.size(2), output_size[0], y_indexed_stride, iy0, iy1, wy0, wy1);
 
     auto sx = std::vector<long>(input.dim(), 1);
     sx[3] = -1;
@@ -107,13 +207,9 @@ at::Tensor ti_upsample_bilinear2d_kernel_impl(
         .add_input(wy1)
         .build();
 
-    int64_t element_size_bytes = input.element_size();
-    int64_t x_indexed_stride = input.stride(3) * element_size_bytes;
-    int64_t y_indexed_stride = input.stride(2) * element_size_bytes;    
-
     AT_DISPATCH_ALL_TYPES(
         iter.dtype(), "upsample_bilinear2d", [&] {
-        ti_cpu_upsample_linear<scalar_t>(iter, y_indexed_stride, x_indexed_stride, [](
+        ti_cpu_upsample_linear<scalar_t>(iter, [](
                 char* dst, char* src, \
                 int64_t offset1, int64_t offset2, char* v0, char* v1, \
                 int64_t offset3, int64_t offset4, char* v2, char* v3)
@@ -123,11 +219,18 @@ at::Tensor ti_upsample_bilinear2d_kernel_impl(
 //               h0lambda * w1lambda * input_indexr(c, ih0, iw1) + /* h0 * w1 * i01 */
 //               h1lambda * w0lambda * input_indexr(c, ih1, iw0) + /* h1 * w0 * i10 */
 //               h1lambda * w1lambda * input_indexr(c, ih1, iw1);  /* h1 * w1 * i11 */            
-            
+//
+
+          *(scalar_t*)dst = *(scalar_t*)v2 * (*(scalar_t*)(src + offset1 + offset3) * *(scalar_t*)v0 + \
+                            *(scalar_t*)(src + offset2 + offset3) * *(scalar_t*)v1) + \
+                            *(scalar_t*)v3 * (*(scalar_t*)(src + offset1 + offset4) * *(scalar_t*)v0 + \
+                            *(scalar_t*)(src + offset2 + offset4) * *(scalar_t*)v1);
+#if 0
           *(scalar_t*)dst = *(scalar_t*)(src + offset1 + offset3) * *(scalar_t*)v0 * *(scalar_t*)v2 + \
                             *(scalar_t*)(src + offset2 + offset3) * *(scalar_t*)v1 * *(scalar_t*)v2 + \
                             *(scalar_t*)(src + offset1 + offset4) * *(scalar_t*)v0 * *(scalar_t*)v3 + \
                             *(scalar_t*)(src + offset2 + offset4) * *(scalar_t*)v1 * *(scalar_t*)v3;
+#endif
         });
     });
 

--- a/step_two/main.cpp
+++ b/step_two/main.cpp
@@ -32,6 +32,13 @@ int main(int argc, char** argv)
 
         if (!ref_out.allclose(out)){
             std::cout << "Error" << std::endl;
+            //std::cout << (ref_out[0][0][0] - out[0][0][0]) << std::endl;
+            auto mse = (ref_out - out).pow(2.0).mean();
+            auto max_e = (ref_out - out).view(-1).abs().max();
+            std::cout << "Error: mse=" << mse << ", max e=" << max_e << std::endl;
+
+            //std::cout << ref_out[0][0][0] << std::endl;
+            //std::cout << out[0][0][0] << std::endl;
             return 1;
         }
 


### PR DESCRIPTION
This PR is not ready for merge, and is meant as a set of guidelines on what we can do to optimize the code even further. We should probably remove the `func_t` being passed as it will probably not be needed, but I've left it there for now.

This PR starts from `step_two` and optimizes it so that it has better cache locality, plus other optimizations.

The current speed-ups I get compared to `step_two` is the following (roughly 3x speedup compared to master for batch size 1, 2x for batch size 32):

<details>

<summary>
Current master (step_two):
</summary>

```
Input tensor: [1, 3, 320, 320]
Num threads: 6

- Check consistency (downsampling to 256x256): OK

- Check consistency (upsampling to 512x512): OK

- Bench upsample_bilinear2d_cpu (5000 rounds) - downsampling to 256x256
Elapsed time: 0.000365611

- Bench ti_upsample_bilinear2d_cpu (5000 rounds) - downsampling to 256x256
Elapsed time: 0.000225859

- Bench upsample_bilinear2d_cpu (5000 rounds) - upsampling to 512x512
Elapsed time: 0.00139943

- Bench ti_upsample_bilinear2d_cpu (5000 rounds) - upsampling to 512x512
Elapsed time: 0.000663689

1 - Benchmark test size as in https://github.com/mingfeima/op_bench-py
Input tensor: [32, 128, 64, 64]
Input is_contiguous memory_format torch.channels_last: 1
Input is_contiguous : 0

- Bench upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.0409884

- Bench ti_upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.111906

2 - Benchmark test size as in https://github.com/mingfeima/op_bench-py
Input tensor: [32, 128, 64, 64]
Input is_contiguous memory_format torch.channels_last: 0
Input is_contiguous : 1

- Bench upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.0947265

- Bench ti_upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.0857989
```

</details>


<details>

<summary>
This PR

</summary>

```
Input tensor: [1, 3, 320, 320]
Num threads: 6

- Check consistency (downsampling to 256x256): OK

- Check consistency (upsampling to 512x512): OK

- Bench upsample_bilinear2d_cpu (5000 rounds) - downsampling to 256x256
Elapsed time: 0.00037262

- Bench ti_upsample_bilinear2d_cpu (5000 rounds) - downsampling to 256x256
Elapsed time: 8.38583e-05

- Bench upsample_bilinear2d_cpu (5000 rounds) - upsampling to 512x512
Elapsed time: 0.00142657

- Bench ti_upsample_bilinear2d_cpu (5000 rounds) - upsampling to 512x512
Elapsed time: 0.00022749

1 - Benchmark test size as in https://github.com/mingfeima/op_bench-py
Input tensor: [32, 128, 64, 64]
Input is_contiguous memory_format torch.channels_last: 1
Input is_contiguous : 0

- Bench upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.0423726

- Bench ti_upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.0672676

2 - Benchmark test size as in https://github.com/mingfeima/op_bench-py
Input tensor: [32, 128, 64, 64]
Input is_contiguous memory_format torch.channels_last: 0
Input is_contiguous : 1

- Bench upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.0927739

- Bench ti_upsample_bilinear2d_cpu (500 rounds) - upsampling to 128x128
Elapsed time: 0.0552326
```

</details>

The commit history is not 100% clean, but should represent different optimizations (or refactorings). Here is a list of what worked:
- special-case the iteration when input stride = 0 and iy stride = 0 -- This should always happen in our current implementation of TensorIterator, but might be good to keep the default case just for safety.
- reorder the computations in the function so that it performs less multiply-adds. So instead of doing `w1 * w2 * x00 + w3 * w2 * x01` I do instead `w2 * (w1 * x00 + w3 * x01)`.
- use a small temporary buffer (of 4 elements) and make the interpolation separable. This gives better cache locality, and provides good speedups
- use `int32_t` for indices. The original reason I did this was to be able to fully exploit vectorization, but seems to give some speed improvements as well. Note that we would need to use `int64_t` indices if the tensors are large, so I would double-check the improvements of using `int32_t` before using it.

Somewhat surprisingly, my first attempt of using vectorized operators yielded slowdowns compared to the past implementation, so I commented it out but left it here for completeness.